### PR TITLE
Update 9menu entry file /etc/9menu

### DIFF
--- a/buildroot/rootfs_overlay/etc/9menu
+++ b/buildroot/rootfs_overlay/etc/9menu
@@ -7,4 +7,5 @@ Machdyne BBS:nxterm "bbs"
 nXkeyboard:nxkbd
 nXmag Magnify:nxmag
 nXview Images:nxterm "/usr/local/nx/bin/nxscriptim"
+Screen Saver:nsaver "12"
 Power Off:nxterm "/usr/local/nx/bin/nxscriptpo"


### PR DESCRIPTION
Add nsaver menu entry as nsaver binary is already compiled as part of the nanox repo build. This will bring the buildroot up to date with the graphical environment development that has occurred in BBS and Email.

@inc this is my first attempt at performing Kakao graphical environment development directly through Github.